### PR TITLE
Fixing some linting and adding /api endpoint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,8 @@
     "no-unused-vars": 1,
     "no-use-before-define": 0,
     "no-shadow": 2,
-    "max-len": [1, {"code": 120, "ignoreStrings": true, "ignoreTemplateLiterals": true}]
+    "max-len": [1, {"code": 120, "ignoreStrings": true, "ignoreTemplateLiterals": true}],
+    "object-curly-spacing": 0,
+    "space-before-function-paren": 0
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ penguin-cronjob/node_modules
 dummy-data
 build
 *.sublime-workspace
+*.env
 
 .DS_Store
 npm-debug.log

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,24 +1,32 @@
 {
-    "preset": "google",
-    "disallowMultipleVarDecl": null,
+  "preset": "google",
+  "disallowMultipleVarDecl": null,
 
-    "excludeFiles": [
-        "**/node_modules/**"
-    ],
+  "excludeFiles": [
+      "**/node_modules/**"
+  ],
 
-    "plugins": [
-        "jscs-jsdoc"
-    ],
+  "plugins": [
+      "jscs-jsdoc"
+  ],
 
-    "jsDoc": {
-        "requireParamDescription": true,
-        "checkAnnotations": "jsdoc3",
-        "checkParamNames": true,
-        "checkRedundantParams": true,
-        "checkRedundantReturns": true,
-        "checkTypes": "strictNativeCase",
-        "checkRedundantAccess": "enforceLeadingUnderscore",
-        "leadingUnderscoreAccess": true,
-        "requireParamTypes": true
-    }
+
+  "jsDoc": {
+    "requireParamDescription": true,
+    "checkAnnotations": "jsdoc3",
+    "checkParamNames": true,
+    "checkRedundantParams": true,
+    "checkRedundantReturns": true,
+    "checkTypes": "strictNativeCase",
+    "checkRedundantAccess": "enforceLeadingUnderscore",
+    "leadingUnderscoreAccess": true,
+    "requireParamTypes": true
+  },
+
+  "maximumLineLength": { "value": 120, "allExcept": [ "comments" ] },
+  "disallowSpacesInsideObjectBrackets": false,
+  "disallowSpacesInAnonymousFunctionExpression": false,
+  "disallowSpacesInFunctionExpression": false,
+  "disallowMultipleLineBreaks": false,
+  "requireDotNotation": false
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "node_modules/babel-cli/bin/babel.js -w source/ -d build/ -s",
+    "dev": "env $(cat .env | xargs) nodemon build",
     "start": "nodemon build",
     "postinstall": "node_modules/babel-cli/bin/babel.js source/ -d build/ -s"
   },


### PR DESCRIPTION
Lint files had different rules for eslint and jscs. I tried to unify them the best I could, but there are differences unsupported by one or the other. I suggest keeping only one linting file.

The other part was about exposing the report data as an API, consumable by the bot I'm working on.